### PR TITLE
Fix links to API in documentation

### DIFF
--- a/doc/getting-started/entry-point.md
+++ b/doc/getting-started/entry-point.md
@@ -1,6 +1,8 @@
 # Entry Point
 
-The class `Packaging` provides the main entry to the library:
+The class [`Packaging`] provides the main entry to the library:
+
+[`Packaging`]: ../api/AasCore.Aas3.Package.Packaging.yml
 
 ```csharp
 var packaging = new AasCore.Aas3.Package.Packaging();

--- a/doc/getting-started/read-write.md
+++ b/doc/getting-started/read-write.md
@@ -2,8 +2,10 @@
 
 We show here how you can open a package for both read/write operations.
 
-We are going to use an instance of [api/AasCore.Aas3.Package.Packaging] to interact with the library.
+We are going to use an instance `packaging` of class [`Packaging`] to interact with the library.
 Please see [intro] for more details.
+
+[`Packaging`]: ../api/AasCore.Aas3.Package.Packaging.yml
 
 ## Creating a New Package
 

--- a/doc/getting-started/reading.md
+++ b/doc/getting-started/reading.md
@@ -1,6 +1,8 @@
 # Reading
 
-Using the `packaging` instance (see [entry-point.md]), we open a package for reading:
+Using the instance `packaging` of class [`Packaging`] (see [entry-point.md]), we open a package for reading:
+
+[`Packaging`]: ../api/AasCore.Aas3.Package.Packaging.yml
 
 ```csharp
 var packaging = new AasCore.Aas3.Package.Packaging();
@@ -45,8 +47,10 @@ Each part has a content type (given as a [MIME type]) and gives you access to it
 
 [MIME type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
 
-A part is modeled as [api/AasCore.Aas3.Package.Part].
+A part is modeled as an instance of class [`Part`].
 You can read all bytes or all text from it, or open a read stream:
+
+[`Part`]: ../api/AasCore.Aas3.Package.Part.yml
 
 ```csharp
 var part = ...;

--- a/src/GenerateDoc.ps1
+++ b/src/GenerateDoc.ps1
@@ -36,7 +36,7 @@ function Main
     }
 
     $siteDir = Join-Path $artefactsDir "gh-pages" `
-        | Join-Path -ChildPath "devdoc"
+        | Join-Path -ChildPath "doc"
 
     Write-Host "The documentation has been generated to: '$siteDir'"
     Write-Host "You can serve it locally with:"


### PR DESCRIPTION
Various references were dangling in the documentation.