### PR TITLE
Introduce a DBC class for contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Aas-package3-csharp is a library for reading and writing packaged file format of
 
 The library is thoroughly tested and ready to be used in production.
 
-Both NETStandard 2.0 and NET 5 are supported.
+Both NET Standard 2.1 and NET 5 are supported.
 
 ## Documentation
 

--- a/doc/getting-started/intro.md
+++ b/doc/getting-started/intro.md
@@ -2,7 +2,7 @@
 
 The following articles describe how you can install and use the library.
 
-The library supports both NET Standard 2.0 and Net 5.
+The library supports both NET Standard 2.1 and Net 5.
 
 Unless a version is indicated as a pre-release, the library has been thoroughly tested and is thus ready for use in production.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -7,7 +7,7 @@ The library allows you to read and write `.aasx` packages, a package format for 
 
 As it name goes, the library operates on packages complying to the [version 3 of the AAS].
 
-The library runs both on NET Standard 2.0 and NET 5. It is thoroughly tested and ready for production.
+The library runs both on NET Standard 2.1 and NET 5. It is thoroughly tested and ready for production.
 
 [version 3 of the AAS]: https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.html
 

--- a/src/AasCore.Aas3.Package.Tests/AasCore.Aas3.Package.Tests.csproj
+++ b/src/AasCore.Aas3.Package.Tests/AasCore.Aas3.Package.Tests.csproj
@@ -10,7 +10,7 @@
 
         <Nullable>enable</Nullable>
 
-        <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
 
         <OutputType>Library</OutputType>
 

--- a/src/AasCore.Aas3.Package.Tests/TestDbc.cs
+++ b/src/AasCore.Aas3.Package.Tests/TestDbc.cs
@@ -1,0 +1,56 @@
+﻿using ArgumentException = System.ArgumentException;
+using InvalidOperationException = System.InvalidOperationException;
+
+using NUnit.Framework;  // can't alias
+
+namespace AasCore.Aas3.Package.Tests
+{
+    public class TestDbc
+    {
+        [Test]
+        public void Test_that_require_doesnt_throw_if_ok()
+        {
+            Dbc.Require(true, "something");
+        }
+
+        [Test]
+        public void Test_the_exception_if_require_fails()
+        {
+            Assert.Catch<ArgumentException>(() =>
+            {
+                Dbc.Require(false, "something");
+            });
+        }
+
+        [Test]
+        public void Test_that_assert_not_null_works()
+        {
+            var something = new byte[3];
+            Dbc.AssertIsNotNull(something);
+        }
+
+        [Test]
+        public void Test_the_exception_from_assert_not_null_with_null()
+        {
+            Assert.Catch<InvalidOperationException>(() =>
+            {
+                Dbc.AssertIsNotNull(null);
+            });
+        }
+
+        [Test]
+        public void Test_that_ensure_doesnt_throw_if_ok()
+        {
+            Dbc.Ensure(true, "something");
+        }
+
+        [Test]
+        public void Test_the_exception_if_ensure_fails()
+        {
+            Assert.Catch<InvalidOperationException>(() =>
+            {
+                Dbc.Ensure(false, "something");
+            });
+        }
+    }
+}

--- a/src/AasCore.Aas3.Package.Tests/TestPackageReadWrite.cs
+++ b/src/AasCore.Aas3.Package.Tests/TestPackageReadWrite.cs
@@ -575,12 +575,22 @@ namespace AasCore.Aas3.Package.Tests
 
             var uri = new Uri("/aasx/some-company/data.txt", UriKind.Relative);
 
+            // Add another spec just to make sure that not *all* specs are deleted
+            var anotherUri = new Uri(
+                "/aasx/some-company/anotherData.txt", UriKind.Relative);
+
             {
                 using var pkg = packaging.Create(pth);
                 pkg.PutSpec(
                     uri,
                     "text/plain",
                     Encoding.UTF8.GetBytes("some content"));
+
+                pkg.PutSpec(
+                    anotherUri,
+                    "text/plain",
+                    Encoding.UTF8.GetBytes("another content"));
+
                 pkg.Flush();
             }
 
@@ -669,12 +679,23 @@ namespace AasCore.Aas3.Package.Tests
 
             var uri = new Uri("/aasx/some-company/suppl.txt", UriKind.Relative);
 
+            // Add another supplementary to make sure that only *one* supplementary
+            // is deleted
+            var anotherUri = new Uri(
+                "/aasx/some-company/suppl1.txt", UriKind.Relative);
+
             {
                 using var pkg = packaging.Create(pth);
                 pkg.PutSupplementary(
                     uri,
                     "text/plain",
                     Encoding.UTF8.GetBytes("some content"));
+
+                pkg.PutSupplementary(
+                    anotherUri,
+                    "text/plain",
+                    Encoding.UTF8.GetBytes("another content"));
+
                 pkg.Flush();
             }
 

--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
         <Nullable>enable</Nullable>
         <Configurations>Debug;Release;DebugSlow</Configurations>
         <Platforms>AnyCPU</Platforms>

--- a/src/AasCore.Aas3.Package/Dbc.cs
+++ b/src/AasCore.Aas3.Package/Dbc.cs
@@ -1,0 +1,37 @@
+﻿using ArgumentException = System.ArgumentException;
+using InvalidOperationException = System.InvalidOperationException;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
+
+namespace AasCore.Aas3.Package
+{
+    /**
+     * Provide methods for design-by-contract.
+     */
+    public static class Dbc
+    {
+        public static void Require(bool value, string message)
+        {
+            if (!value)
+            {
+                throw new ArgumentException(message);
+            }
+        }
+
+        public static void AssertIsNotNull([NotNull] object? @object)
+        {
+            if (@object == null)
+            {
+                throw new InvalidOperationException("Unexpected null");
+            }
+        }
+
+
+        public static void Ensure(bool value, string message)
+        {
+            if (!value)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch introduces a separate class to encapsulate the contract logic
as it is quite hard to read the code in a reversed logic
(if-not-postcondition-then-throw).

Additionally, as not-null checks obscured the code coverage, we
introduce a not-null assertion function. To that end, we had to use
`NotNullAttribute` which is available only in NET Standard 2.1. This
forced us thus to bump to NET Standard 2.1 from 2.0.