### PR TITLE
Fix code in Readme to use `ContainsKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ byte[] supplementaryContent;
 
     // Read the specs
     var specsByContentType = pkg.SpecsByContentType();
-    if (!specsByContentType.Contains("text/json"))
+    if (!specsByContentType.ContainsKey("text/json"))
     {
         throw new ArgumentException("No json specs");
     }

--- a/src/AasCore.Aas3.Package.Tests/TestPackageRead.cs
+++ b/src/AasCore.Aas3.Package.Tests/TestPackageRead.cs
@@ -127,6 +127,10 @@ namespace AasCore.Aas3.Package.Tests
                 Assert.That(specsByContentType.Keys.ToList(),
                     Is.EquivalentTo(new List<string> { "text/json", "text/xml" }));
 
+                // Test this for the Readme.
+                Assert.That(specsByContentType.ContainsKey("text/json"));
+                Assert.That(specsByContentType.ContainsKey("text/xml"));
+
                 foreach (var item in specsByContentType)
                 {
                     var contentType = item.Key;


### PR DESCRIPTION
There was an error in the code snippet presented in the readme. Instead
of `Contains(.)`, `ContainsKey(.)` should be used when checking for
specs.