### PR TITLE
Move dependencies in `<metadata>` in Nuspec

### DIFF
--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.nuspec
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>AasCore.Aas3.Package</id>
-    <version>1.0.0-pre4</version>
+    <version>1.0.0-pre5</version>
     <title>AAS v3 Package Library</title>
     <authors>Marko Ristin, Nico Braunisch, Robert Lehmann</authors>
     <owners>$author$</owners>
@@ -13,6 +13,9 @@
 A library for reading and writing packaged file format of an Asset Administration Shell (AAS) v3
     </description>
     <copyright>Copyright (c) 2021</copyright>
+    <dependencies>
+        <dependency id="System.IO.Packaging" version="[5,6)" />
+    </dependencies>
     <releaseNotes>v1.0.0-pre3
 * Fix nuspec so that DLLs are packaged to lib/ (#15)
 
@@ -27,7 +30,4 @@ v1.0.0-pre1
   <files>
      <file src="bin\Release\**\*.dll" target="lib" />
   </files>
-  <dependencies>
-    <dependency id="System.IO.Packaging" version="[5,6)" />
-  </dependencies>
 </package>


### PR DESCRIPTION
There was an error in the previous nuspec causing the dependencies to be
ignored.