### PR TITLE
Add support for netstandard 2.0

### DIFF
--- a/src/.idea/.idea.aas-package3-csharp/.idea/inspectionProfiles/Project_Default.xml
+++ b/src/.idea/.idea.aas-package3-csharp/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+﻿<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="HttpUrlsUsage" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/src/AasCore.Aas3.Package.Tests/AasCore.Aas3.Package.Tests.csproj
+++ b/src/AasCore.Aas3.Package.Tests/AasCore.Aas3.Package.Tests.csproj
@@ -10,7 +10,7 @@
 
         <Nullable>enable</Nullable>
 
-        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
 
         <OutputType>Library</OutputType>
 

--- a/src/AasCore.Aas3.Package.Tests/TestDbc.cs
+++ b/src/AasCore.Aas3.Package.Tests/TestDbc.cs
@@ -23,22 +23,6 @@ namespace AasCore.Aas3.Package.Tests
         }
 
         [Test]
-        public void Test_that_assert_not_null_works()
-        {
-            var something = new byte[3];
-            Dbc.AssertIsNotNull(something);
-        }
-
-        [Test]
-        public void Test_the_exception_from_assert_not_null_with_null()
-        {
-            Assert.Catch<InvalidOperationException>(() =>
-            {
-                Dbc.AssertIsNotNull(null);
-            });
-        }
-
-        [Test]
         public void Test_that_ensure_doesnt_throw_if_ok()
         {
             Dbc.Ensure(true, "something");

--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <Configurations>Debug;Release;DebugSlow</Configurations>
         <Platforms>AnyCPU</Platforms>

--- a/src/AasCore.Aas3.Package/Dbc.cs
+++ b/src/AasCore.Aas3.Package/Dbc.cs
@@ -1,6 +1,5 @@
 ﻿using ArgumentException = System.ArgumentException;
 using InvalidOperationException = System.InvalidOperationException;
-using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace AasCore.Aas3.Package
 {
@@ -16,15 +15,6 @@ namespace AasCore.Aas3.Package
                 throw new ArgumentException(message);
             }
         }
-
-        public static void AssertIsNotNull([NotNull] object? @object)
-        {
-            if (@object == null)
-            {
-                throw new InvalidOperationException("Unexpected null");
-            }
-        }
-
 
         public static void Ensure(bool value, string message)
         {

--- a/src/AasCore.Aas3.Package/Package.cs
+++ b/src/AasCore.Aas3.Package/Package.cs
@@ -80,7 +80,10 @@ namespace AasCore.Aas3.Package
                 throw MaybeException;
             }
 
-            Dbc.AssertIsNotNull(_package);
+            if (_package == null)
+            {
+                throw new InvalidOperationException("Unexpected null _package");
+            }
 
             return _package;
         }
@@ -326,7 +329,11 @@ namespace AasCore.Aas3.Package
                 result = new PackageOrException<PackageRead>(null, exception);
             }
 
-            Dbc.AssertIsNotNull(result);
+            if (result == null)
+            {
+                throw new InvalidOperationException("Unexpected null result");
+            }
+
 
             // Dispose the toBeDisposed pre-emptively here so that they do not have to
             // linger unnecessarily in the resulting object.
@@ -395,7 +402,10 @@ namespace AasCore.Aas3.Package
                 result = new PackageOrException<PackageRead>(null, exception);
             }
 
-            Dbc.AssertIsNotNull(result);
+            if (result == null)
+            {
+                throw new InvalidOperationException("Unexpected null result");
+            }
 
             // Dispose the toBeDisposed pre-emptively here so that they do not have to
             // linger unnecessarily in the resulting object.
@@ -474,7 +484,10 @@ namespace AasCore.Aas3.Package
                 result = new PackageOrException<PackageReadWrite>(null, exception);
             }
 
-            Dbc.AssertIsNotNull(result);
+            if (result == null)
+            {
+                throw new InvalidOperationException("Unexpected null result");
+            }
 
             // Dispose the toBeDisposed pre-emptively here so that they do not have to
             // linger unnecessarily in the resulting object.
@@ -547,7 +560,10 @@ namespace AasCore.Aas3.Package
                 result = new PackageOrException<PackageReadWrite>(null, exception);
             }
 
-            Dbc.AssertIsNotNull(result);
+            if (result == null)
+            {
+                throw new InvalidOperationException("Unexpected null result");
+            }
 
             // Dispose the toBeDisposed pre-emptively here so that they do not have to
             // linger unnecessarily in the resulting object.
@@ -1232,8 +1248,9 @@ namespace AasCore.Aas3.Package
 
 #if DEBUGSLOW
 
-            var oldSpecUriSet = Specs()
-                .Select(spec => spec.Uri.ToString()).ToHashSet();
+            var oldSpecUriSet = new HashSet<string>(
+                Specs()
+                .Select(spec => spec.Uri.ToString()));
 
 #endif
 
@@ -1275,8 +1292,8 @@ namespace AasCore.Aas3.Package
                     Specs().All(aSpec => aSpec.Uri != uri),
                     "The spec must not be listed in the Specs().");
 
-                var specUriSet = Specs()
-                    .Select(spec => spec.Uri.ToString()).ToHashSet();
+                var specUriSet = new HashSet<string>(Specs()
+                    .Select(spec => spec.Uri.ToString()));
 
                 Dbc.Ensure(
                     specUriSet.Count == oldSpecUriSet.Count - 1
@@ -1308,8 +1325,8 @@ namespace AasCore.Aas3.Package
 
 #if DEBUGSLOW
 
-            var oldSupplUriSet = Supplementaries()
-                .Select(suppl => suppl.Uri.ToString()).ToHashSet();
+            var oldSupplUriSet = new HashSet<string>(Supplementaries()
+                .Select(suppl => suppl.Uri.ToString()));
 
 #endif
 
@@ -1351,8 +1368,8 @@ namespace AasCore.Aas3.Package
                     "The supplementary file must not be " +
                     "listed in the Supplementaries().");
 
-                var supplUriSet = Supplementaries()
-                    .Select(suppl => suppl.Uri.ToString()).ToHashSet();
+                var supplUriSet = new HashSet<string>(Supplementaries()
+                    .Select(suppl => suppl.Uri.ToString()));
 
                 Dbc.Ensure(
                     supplUriSet.Count == oldSupplUriSet.Count - 1


### PR DESCRIPTION
In this patch, we dispense of the features from netstandard 2.1 (such as
`ToHashSet`) so that we can support netstandard 2.0 as well.

Notably, this support is necessary so that we can use the library
together with aasx-package-explorer.

Unfortunately, we could not use NotNull annotation anymore, so
assertions could not be ignored in the code coverage finally
resulting in lower coverage.