### PR TITLE
Add support for `System.IO.Packaging` 4

### DIFF
--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
@@ -10,6 +10,6 @@
 
     <ItemGroup>
       <!-- don't forget to update the .nuspec. -->
-      <PackageReference Include="System.IO.Packaging" Version="5.*" />
+      <PackageReference Include="System.IO.Packaging" Version="4.*" />
     </ItemGroup>
 </Project>

--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.nuspec
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>AasCore.Aas3.Package</id>
-    <version>1.0.0-pre5</version>
+    <version>1.0.0-pre5-debug</version>
     <title>AAS v3 Package Library</title>
     <authors>Marko Ristin, Nico Braunisch, Robert Lehmann</authors>
     <owners>$author$</owners>
@@ -14,7 +14,7 @@ A library for reading and writing packaged file format of an Asset Administratio
     </description>
     <copyright>Copyright (c) 2021</copyright>
     <dependencies>
-        <dependency id="System.IO.Packaging" version="[5,6)" />
+        <dependency id="System.IO.Packaging" version="[4,6)" />
     </dependencies>
     <releaseNotes>v1.0.0-pre3
 * Fix nuspec so that DLLs are packaged to lib/ (#15)


### PR DESCRIPTION
It is necessary to downgrade the supported version from 5 to 4 so that
the package can be used with aasx-package explorer which depends
currently on version 4.