### PR TITLE
Fix relating supplementaries to specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Aas-package3-csharp is a library for reading and writing packaged file format of
 
 The library is thoroughly tested and meant to be used in production.
 
-Both NET Standard 2.1 and NET 5 are supported.
+NET Standard 2.0, NET Standard 2.1 and NET 5 are supported.
 
 ## Documentation
 
@@ -40,21 +40,30 @@ var packaging = new AasCore.Aas3.Package.Packaging();
     byte[] supplementaryContent = ...;
 
     using var pkg = packaging.Create("/path/to/some/file");
-    pkg.PutSpec(
-        new Uri("/aasx/some-company/data.json", UriKind.Relative),
-        "text/json",
-        specContent);
+    var spec = pkg.MakeSpec(
+        pkg.PutPart(
+            new Uri(
+                "/aasx/some-company/data.json", 
+                UriKind.Relative),
+            "text/json",
+            specContent);
 
-    pkg.PutThumbnail(
-        new Uri("/some-thumbnail.png", UriKind.Relative),
-        "image/png",
-        thumbnailContent,
-        true);
+    pkg.MakeThumbnail(
+        pkg.PutPart(
+            new Uri(
+                "/some-thumbnail.png", 
+                UriKind.Relative),
+            "image/png",
+            thumbnailContent));
 
-    pkg.PutSupplementary(
-        new Uri("/aasx-suppl/some-company/some-manual.pdf", UriKind.Relative),
-        "application/pdf",
-        supplementaryContent);
+    pkg.RelateSupplementaryToSpec(
+        pkg.PutPart(
+            new Uri(
+                "/aasx-suppl/some-company/some-manual.pdf",
+                 UriKind.Relative),
+            "application/pdf",
+            supplementaryContent),
+        spec);
 
     pkg.Flush();
 }
@@ -87,12 +96,20 @@ byte[] supplementaryContent;
     specContent = spec.ReadAllBytes();
 
     // Read the thumbnail
-    thumbnailContent = pkg.Thumbnail().ReadAllBytes();
+    var thumbnail = pkg.Thumbnail();
+    if(thumbnail != null)
+    {
+        thumbnailContent = pkg.Thumbnail().ReadAllBytes();
+
+        // Do something with the thumbnail content
+    }
 
     // Read the supplementary file
     supplementaryContent = pkg
-        .FindPart(
-            new Uri("/aasx-suppl/some-company/some-manual.pdf", UriKind.Relative))
+        .MustPart(
+            new Uri(
+                "/aasx-suppl/some-company/some-manual.pdf",
+                 UriKind.Relative))
         .ReadAllBytes();
 }
 ```

--- a/doc/getting-started/intro.md
+++ b/doc/getting-started/intro.md
@@ -2,7 +2,7 @@
 
 The following articles describe how you can install and use the library.
 
-The library supports both NET Standard 2.1 and Net 5.
+The library supports NET Standard 2.0, NET Standard 2.1 and Net 5.
 
 Unless a version is indicated as a pre-release, the library has been thoroughly tested and is thus ready for use in production.
 

--- a/doc/getting-started/reading.md
+++ b/doc/getting-started/reading.md
@@ -102,7 +102,7 @@ else
 According to [Details of the Asset Administration Shell v3], specs should all represent the same data model albeit in a different format.
 Multiple equivalent models per content type are also possible.
 
-## Supplementaries
+## Supplementary Materials
 
 If you know the [URI] of a supplementary part within the package, you can directly access it:
 
@@ -123,10 +123,12 @@ if(suppl != null)
 }
 ```
 
-Otherwise, if you want to inspect all the supplementary parts, you can list them:
+Otherwise, if you want to inspect all the supplementary parts for a given spec, you can list them:
 
 ```csharp
-foreach(AasCore.Aas3.Package.Part suppl in pkg.Supplementaries())
+var spec = pkg.MustPart(...);
+
+foreach(AasCore.Aas3.Package.Part suppl in pkg.SupplementariesFor(spec))
 {
     // Do something with suppl
 }

--- a/doc/index.md
+++ b/doc/index.md
@@ -7,7 +7,7 @@ The library allows you to read and write `.aasx` packages, a package format for 
 
 As it name goes, the library operates on packages complying to the [version 3 of the AAS].
 
-The library runs both on NET Standard 2.1 and NET 5. It is thoroughly tested and ready for production.
+The library runs on NET Standard 2.0, NET Standard 2.1 and NET 5. It is thoroughly tested and ready for production.
 
 [version 3 of the AAS]: https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.html
 

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/01_Festo/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/01_Festo/supplementariesTable.txt
@@ -1,2 +1,18 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                         | Spec Content Type | Spec URI
+---------------------------+-----------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/assetIdentification/logo.png                        | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/png                  | /aasx/Nameplate/marking_ce.png                            | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/png                  | /aasx/Nameplate/marking_WEEE.png                          | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/CE_Kennzeichnung_2016_de.pdf               | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/RoHS_2011_65_EU_Konzern_Information_de.pdf | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/jpeg                 | /aasx/Nameplate/marking_cruus.jpg                         | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/jpeg                 | /aasx/Nameplate/marking_rcm.jpg                           | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/SPAE_UL_4531318_-_2_EN.pdf                 | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/OVEL_IO_Link_5439356_-_3_EN.pdf            | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/OVEL_DNVGL_5309107_-_3_EN.pdf              | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/OVEL_2017-05_8070876g1_EN.pdf              | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/OVEL_2017-05_8070875d1_DE.pdf              | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/SPAE_2017-03b_8058481d1_DE.pdf             | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/SPAE_2017-03b_8058481d1_EN.pdf             | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/SPAE_100017_ApplNote.pdf                   | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+text/plain                 | /aasx/Software/Festo-SPAE-kPa-20171025-IODD1.1.zip        | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/02_Bosch/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/02_Bosch/supplementariesTable.txt
@@ -1,2 +1,13 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                                        | Spec Content Type | Spec URI
+---------------------------+--------------------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                                           | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Lohr_Bosch-Rexroth-AG_ISO_14001_BR_Matrix_en_20090723.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/logo.png                                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/DCTC-30434-002_KOE_M_NN_2019-01-01.pdf                    | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/DCMC-01001-000_KOB_N_EN_2019-06-14.pdf                    | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/3608870EF2_AC.pdf                                         | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/3608870A47_AE_DE.pdf                                      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/3608870A47_AE_EN.pdf                                      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/36088702DE_AA.pdf                                         | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/36088702EN_AA.pdf                                         | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/EU_Declaration_of_Conformity.pdf                          | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/03_Bosch/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/03_Bosch/supplementariesTable.txt
@@ -1,2 +1,4 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI              | Spec Content Type | Spec URI
+---------------------------+--------------------------------+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+N/A                        | N/A                            | N/A               | The relationship from spec /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml as supplementary material to /aasx/Nameplate/Logo_IO-link.jpg exists, but the underlying part does not.

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/04_Bosch/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/04_Bosch/supplementariesTable.txt
@@ -1,2 +1,13 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                                        | Spec Content Type | Spec URI
+---------------------------+--------------------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                                           | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Lohr_Bosch-Rexroth-AG_ISO_14001_BR_Matrix_en_20090723.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/logo.png                                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/EU_Declaration_of_Conformity.pdf                          | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Doku_Schmierung_CKx_V01_R320103051_2017_03.pdf            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103141_2015_06_Einbauerklaerung_einachsig.pdf         | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103152_2015_01_DE_Safety_LS_Media_22_01_2015.pdf      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103152_2015_01_EN_Safety_LS_22_01_2015_web.pdf        | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103982_DE_EN_FR_IT_(2015_05)_CKK.pdf                  | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R999000479_2019_03_DE_18_07_2019_CKx.pdf                  | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R999000499_2019_03_EN_18_07_2019_CKx.pdf                  | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/05_Bosch/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/05_Bosch/supplementariesTable.txt
@@ -1,2 +1,11 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                                        | Spec Content Type | Spec URI
+---------------------------+--------------------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                                           | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Lohr_Bosch-Rexroth-AG_ISO_14001_BR_Matrix_en_20090723.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/logo.png                                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Doku_Schmierung_CKx_V01_R320103051_2017_03.pdf            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103141_2015_06_Einbauerklaerung_einachsig.pdf         | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103152_2015_01_DE_Safety_LS_Media_22_01_2015.pdf      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103152_2015_01_EN_Safety_LS_22_01_2015_web.pdf        | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R999000479_2019_03_DE_18_07_2019_CKx.pdf                  | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R999000499_2019_03_EN_18_07_2019_CKx_(1).pdf              | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/06_Bosch/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/06_Bosch/supplementariesTable.txt
@@ -1,2 +1,12 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                                        | Spec Content Type | Spec URI
+---------------------------+--------------------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                                           | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Lohr_Bosch-Rexroth-AG_ISO_14001_BR_Matrix_en_20090723.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/logo.png                                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/EU_Declaration_of_Conformity.pdf                          | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Anleitung-R320103187_2006_09_2.pdf                        | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Katalog-DE_R999000480_2015-12_PSK_24_10_2018_Gy.pdf       | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Katalog-EN_R999000500_2015-12_PSK_24_10_2018_Gy.pdf       | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103141_2015_06_Einbauerklaerung_einachsig.pdf         | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103152_2015_01_DE_Safety_LS_Media_22_01_2015.pdf      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/R320103152_2015_01_EN_Safety_LS_22_01_2015_web.pdf        | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/07_PhoenixContact/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/07_PhoenixContact/supplementariesTable.txt
@@ -1,2 +1,6 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                      | Spec Content Type | Spec URI
+---------------------------+----------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png         | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/EU_Declaration_of_Conformity.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/PhoenixContact_Logo.png          | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/jpeg                 | /aasx/2904622_QRCode.jpeg              | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/08_SchneiderElectric/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/08_SchneiderElectric/supplementariesTable.txt
@@ -1,2 +1,12 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                           | Spec Content Type | Spec URI
+---------------------------+-------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                              | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/logo_SE.png                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Nameplate/UL.png                                      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/TPRBCEIP.PNG                           | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/jpeg                 | /aasx/Identification/QRCode_Tesys_Island_Header.jpg         | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/CE_TPRBC_SC19062501.pdf                      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/PROGRAMMABLE_CONTROLLERS___UL_Product_iQ.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Instal_EN.pdf                                | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Instal_DE.pdf                                | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Nameplate/Marking_WEEE.png                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/09_SchneiderElectric/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/09_SchneiderElectric/supplementariesTable.txt
@@ -1,2 +1,12 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                           | Spec Content Type | Spec URI
+---------------------------+-------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                              | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/logo_SE.png                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Nameplate/UL.png                                      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/PROGRAMMABLE_CONTROLLERS___UL_Product_iQ.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Instal_EN.pdf                                | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Instal_DE.pdf                                | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Nameplate/Marking_WEEE.png                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/TPRVM001.PNG                           | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/CE_TPRVM_SC19062503.pdf                      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/jpeg                 | /aasx/Identification/QRCode_Tesys_Island_Power.jpg          | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/10_SchneiderElectric/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/10_SchneiderElectric/supplementariesTable.txt
@@ -1,2 +1,12 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                           | Spec Content Type | Spec URI
+---------------------------+-------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                              | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/logo_SE.png                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Nameplate/UL.png                                      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/PROGRAMMABLE_CONTROLLERS___UL_Product_iQ.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Instal_EN.pdf                                | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/Instal_DE.pdf                                | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Nameplate/Marking_WEEE.png                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/CE_TPRSx_SC19062505.pdf                      | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/TPRST009.PNG                           | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/jpeg                 | /aasx/Identification/QRCode_Tesys_Island_Starter.jpg        | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/11_SchneiderElectric/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/11_SchneiderElectric/supplementariesTable.txt
@@ -1,2 +1,11 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                                                 | Spec Content Type | Spec URI
+---------------------------+-----------------------------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                                                    | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/M262.PNG                                                     | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Identification/logo_SE.png                                                  | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/MOD2019002.00_DeclarationOfConformity_TM262_TMS_TM3XHSC_signed.pdf | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Nameplate/UL.png                                                            | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/M262_20190513_Notice_of_Authorization.pdf                          | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/jpeg                 | /aasx/Identification/QRCode_M262.JPG                                              | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+image/png                  | /aasx/Nameplate/Marking_WEEE.png                                                  | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml
+application/pdf            | /aasx/Document/IS_M262.pdf                                                        | text/xml          | /aasx/wwwcompanycomidsaas2520_6010_8091_1277/wwwcompanycomidsaas2520_6010_8091_1277.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/12_Pepperl+Fuchs/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/12_Pepperl+Fuchs/supplementariesTable.txt
@@ -1,2 +1,5 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                             | Spec Content Type | Spec URI
+---------------------------+-----------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+application/pdf            | /aasx/Document/EU-Konformitaetserklaerung.pdf | text/xml          | /aasx/wwwcompanycomidsaas8403_3140_0191_8844/wwwcompanycomidsaas8403_3140_0191_8844.aas.xml
+application/pdf            | /aasx/Document/267075-100078_eng.pdf          | text/xml          | /aasx/wwwcompanycomidsaas8403_3140_0191_8844/wwwcompanycomidsaas8403_3140_0191_8844.aas.xml
+image/jpeg                 | /aasx/Identification/PF_Logo_RGB.jpg          | text/xml          | /aasx/wwwcompanycomidsaas8403_3140_0191_8844/wwwcompanycomidsaas8403_3140_0191_8844.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/13_DKE/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/13_DKE/supplementariesTable.txt
@@ -1,2 +1,6 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI      | Spec Content Type | Spec URI
+---------------------------+------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/jpeg                 | /aasx/dke-logo.jpg     | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+text/plain                 | /aasx/dke-logo-all.tif | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/png                  | /aasx/dke-qr.png       | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/jpeg                 | /aasx/dke-dose.jpg     | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/14_Siemens/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/14_Siemens/supplementariesTable.txt
@@ -1,2 +1,11 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                                    | Spec Content Type | Spec URI
+---------------------------+----------------------------------------------------------------------+-------------------+------------------------------------------------------------------------------------------------------
+image/png                  | /aasx/Identification/qrcode_P320.png                                 | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml
+image/jpeg                 | /aasx/Identification/sie-logo-layer-petrol-rgb.jpg                   | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml
+application/pdf            | /aasx/Document/cert_EU-DoC_SitP320_P420_A5E44320812A_002.pdf         | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml
+application/pdf            | /aasx/Document/cert__SIP320_P420_Exi_Exd_de_en_BVS_18_ATEX_E049X.pdf | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml
+application/pdf            | /aasx/Document/A5E41285171-ABde_P320P420_HART_OI_de-DE.pdf           | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml
+application/pdf            | /aasx/Document/A5E44852162-ABen_P320P420_HART_OI_en-US.pdf           | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml
+application/pdf            | /aasx/Document/A5E38874562-ABde_P320P420_COI_de-DE.pdf               | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml
+application/pdf            | /aasx/Document/A5E38874562-ABen_P320P420_COI_en-US.pdf               | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml
+image/png                  | /aasx/Nameplate/marking_ce.png                                       | text/xml          | /aasx/www_company_com_ids_aas_9460_8042_0191_4407/www_company_com_ids_aas_9460_8042_0191_4407.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/15_Siemens/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/15_Siemens/supplementariesTable.txt
@@ -1,2 +1,10 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                                 | Spec Content Type | Spec URI
+---------------------------+-------------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------------------------
+image/png                  | /aasx/Nameplate/marking_ce.png                                    | text/xml          | /aasx/www_company_com_demo_aas_1234554842136874684321/www_company_com_demo_aas_1234554842136874684321.aas.xml
+image/jpeg                 | /aasx/Identification/sie-logo-layer-petrol-rgb.jpg                | text/xml          | /aasx/www_company_com_demo_aas_1234554842136874684321/www_company_com_demo_aas_1234554842136874684321.aas.xml
+image/jpeg                 | /aasx/Nameplate/marking_UL.jpg                                    | text/xml          | /aasx/www_company_com_demo_aas_1234554842136874684321/www_company_com_demo_aas_1234554842136874684321.aas.xml
+text/plain                 | /aasx/Identification/dmc.gif                                      | text/xml          | /aasx/www_company_com_demo_aas_1234554842136874684321/www_company_com_demo_aas_1234554842136874684321.aas.xml
+application/pdf            | /aasx/Document/106_CE_S7_1500_general_A3_10_2019_d_e.pdf          | text/xml          | /aasx/www_company_com_demo_aas_1234554842136874684321/www_company_com_demo_aas_1234554842136874684321.aas.xml
+application/pdf            | /aasx/Document/s71200_1500_f_cpus_product_information_x_de-DE.pdf | text/xml          | /aasx/www_company_com_demo_aas_1234554842136874684321/www_company_com_demo_aas_1234554842136874684321.aas.xml
+application/pdf            | /aasx/Document/S7-1500_Vol.9_Sec.1_E222109.pdf                    | text/xml          | /aasx/www_company_com_demo_aas_1234554842136874684321/www_company_com_demo_aas_1234554842136874684321.aas.xml
+application/pdf            | /aasx/Document/ProgFAILenUS_en-US.pdf                             | text/xml          | /aasx/www_company_com_demo_aas_1234554842136874684321/www_company_com_demo_aas_1234554842136874684321.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/16_Lenze/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/16_Lenze/supplementariesTable.txt
@@ -1,2 +1,8 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                        | Spec Content Type | Spec URI
+---------------------------+----------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/Identification/logo.png                            | text/xml          | /aasx/wwwcompanycomidsaas6265_9010_8091_8913/wwwcompanycomidsaas6265_9010_8091_8913.aas.xml
+application/pdf            | /aasx/Document/EU_Declaration_of_Conformity.pdf          | text/xml          | /aasx/wwwcompanycomidsaas6265_9010_8091_8913/wwwcompanycomidsaas6265_9010_8091_8913.aas.xml
+image/png                  | /aasx/Nameplate/marking_ce.png                           | text/xml          | /aasx/wwwcompanycomidsaas6265_9010_8091_8913/wwwcompanycomidsaas6265_9010_8091_8913.aas.xml
+image/jpeg                 | /aasx/Identification/thumbnail.jpeg                      | text/xml          | /aasx/wwwcompanycomidsaas6265_9010_8091_8913/wwwcompanycomidsaas6265_9010_8091_8913.aas.xml
+application/pdf            | /aasx/Document/UL-Approbation_Servoumrichter_i950_xx.pdf | text/xml          | /aasx/wwwcompanycomidsaas6265_9010_8091_8913/wwwcompanycomidsaas6265_9010_8091_8913.aas.xml
+image/png                  | /aasx/Nameplate/UL_Mark.png                              | text/xml          | /aasx/wwwcompanycomidsaas6265_9010_8091_8913/wwwcompanycomidsaas6265_9010_8091_8913.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/17_ABB/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/17_ABB/supplementariesTable.txt
@@ -1,2 +1,8 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                        | Spec Content Type | Spec URI
+---------------------------+------------------------------------------+-------------------+------------------------------------------------------------------------------
+application/pdf            | /aasx/OI_TTF300_DE_G01.pdf               | text/xml          | /aasx/www_abb_com_8055_9070_1191_2593/www_abb_com_8055_9070_1191_2593.aas.xml
+application/pdf            | /aasx/OI_TTF300_EN_G01.pdf               | text/xml          | /aasx/www_abb_com_8055_9070_1191_2593/www_abb_com_8055_9070_1191_2593.aas.xml
+application/pdf            | /aasx/CE_TTX300_TTX200_ATEX_2016X-DE.pdf | text/xml          | /aasx/www_abb_com_8055_9070_1191_2593/www_abb_com_8055_9070_1191_2593.aas.xml
+image/png                  | /aasx/ABB_Logo_320.png                   | text/xml          | /aasx/www_abb_com_8055_9070_1191_2593/www_abb_com_8055_9070_1191_2593.aas.xml
+image/png                  | /aasx/QR_9AAC129110_3K650000548505.png   | text/xml          | /aasx/www_abb_com_8055_9070_1191_2593/www_abb_com_8055_9070_1191_2593.aas.xml
+image/png                  | /aasx/Nameplate/marking_ce.png           | text/xml          | /aasx/www_abb_com_8055_9070_1191_2593/www_abb_com_8055_9070_1191_2593.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/18_Hitachi/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/18_Hitachi/supplementariesTable.txt
@@ -1,2 +1,14 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                              | Spec Content Type | Spec URI
+---------------------------+----------------------------------------------------------------+-------------------+--------------------------------------------------------------------------------------------
+image/png                  | /aasx/assetIdentification/logo.png                             | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/png                  | /aasx/Nameplate/marking_ce.png                                 | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/jpeg                 | /aasx/Nameplate/marking_cruus.jpg                              | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/jpeg                 | /aasx/Nameplate/marking_rcm.jpg                                | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+image/png                  | /aasx/assetIdentification/Hitachi_logo.png                     | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/NJI-637A(X)_HX-CPU_Hardware_Rev_01.pdf          | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/CE_DLR_EH-150_REV17.pdf                         | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/NJI-638X_HX-CPU_Software.pdf                    | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/CODESYS_Installation_und_Erste_Schritte_V11.pdf | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/HX_Datasheet.pdf                                | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+text/plain                 | /aasx/Document/Device_files.zip                                | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml
+application/pdf            | /aasx/Document/NJI-638_HX-CPU_SoftwareJP.pdf                   | text/xml          | /aasx/wwwcompanycomidsaas9350_1162_7091_7335/wwwcompanycomidsaas9350_1162_7091_7335.aas.xml

--- a/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/34_Festo/supplementariesTable.txt
+++ b/src/AasCore.Aas3.Package.Tests/TestResources/AasCore.Aas3.Package.Tests/TestPackageRead/34_Festo/supplementariesTable.txt
@@ -1,2 +1,37 @@
-Content Type | URI
--------------+----
+Supplementary Content Type | Supplementary URI                                           | Spec Content Type | Spec URI
+---------------------------+-------------------------------------------------------------+-------------------+----------------------------------------------------------------
+image/png                  | /aasx/nameplate/marking__atex.png                           | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/marking_ce_5fa922fa.png                       | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/marking_rcm_d9effd37.png                      | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/thumbnail_3e8440cf.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/AssetQrCode_c67e237a.png                      | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/FestoLogo_fd4760bc.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/FestoLogo_ba43692f.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/thumbnail_996abd44.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/jpeg                 | /aasx/VDI2770/00991433_6522fecf.jpg                         | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/thumbnail_181f37c2.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/cULUS_717e0f15.png                            | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/thumbnail_e19ef8d6.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/thumbnail_91e1ec5c.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/00991153_c8b39ba3.png                         | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/thumbnail_b5448fbf.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/00991153_1ca23d68.png                         | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/thumbnail_594ff872.png                        | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+image/png                  | /aasx/VDI2770/00991153_c14f51f5.png                         | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/574337_SMT-8M-A-PS-24V-E-03-M12_18cc19e9.pdf  | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/step           | /aasx/VDI2770/574337_SMT-8M-A-PS-24V-E-03-M12_4d610db1.stp  | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+text/plain                 | /aasx/VDI2770/FES.574337_d361125a.edz                       | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/SMT-8M-A_2017-11d_8082624g3_15edb0c3.pdf      | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/EU-LANGUAGES_2016-06c_8062970g1_a8f4a750.pdf  | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/Techinfo_en_41658035.pdf                      | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/smx8_de_9567a097.pdf                          | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/smx8_en_7425f6c4.pdf                          | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/Entsorgungshinweise_de_ef974885.pdf           | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/Waste_Management_Instructions_en_05b26eb6.pdf | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/Einsatz_072011_de_a3988c74.pdf                | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/Use_82011_en_df930930.pdf                     | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/Ersatzteilfinder_8dda6155.pdf                 | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/Spare_parts_catalogue_37e1de33.pdf            | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/EMC_Checklist_aa008d14.pdf                    | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/5436023_-_2_bdbee314.pdf                      | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml
+application/pdf            | /aasx/VDI2770/5468038_-_5_8608d292.pdf                      | text/xml          | /aasx/pk_festo_com_3S7PN93V62Q/pk_festo_com_3S7PN93V62Q.aas.xml

--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.nuspec
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>AasCore.Aas3.Package</id>
-    <version>1.0.0-pre5-debug</version>
+    <version>1.0.0-pre5-debug3</version>
     <title>AAS v3 Package Library</title>
     <authors>Marko Ristin, Nico Braunisch, Robert Lehmann</authors>
     <owners>$author$</owners>

--- a/src/aas-package3-csharp.sln.DotSettings
+++ b/src/aas-package3-csharp.sln.DotSettings
@@ -5,4 +5,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=moriturus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mristin/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rels/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=supplementaries/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=supplementaries/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unrelate/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
There was a grand bug in the current code. Namely, supplementary
materials are related to specs, according to the book [1] (page 120),
but our implementation related them to the origin.

This lead to a complete overhaul of the public interface.

[1]: https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.html