### PR TITLE
Release 1.0.0-pre6

### DIFF
--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.nuspec
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>AasCore.Aas3.Package</id>
-    <version>1.0.0-pre5-debug3</version>
+    <version>1.0.0-pre6</version>
     <title>AAS v3 Package Library</title>
     <authors>Marko Ristin, Nico Braunisch, Robert Lehmann</authors>
     <owners>$author$</owners>


### PR DESCRIPTION
* Fix relating supplementaries to specs (#21)
* Add support for `System.IO.Packaging` 4 (#20)
* Add support for netstandard 2.0 (#19)