### PR TITLE
Add additional info to csproj

### DIFF
--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
@@ -13,6 +13,12 @@
         <Description>
             A library for reading and writing packaged file format of an Asset Administration Shell (AAS) v3
         </Description>
+        <RepositoryUrl>https://github.com/aas-core-works/aas-package3-csharp.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <Copyright>Copyright (c) 2021 Marko Ristin, Nico Braunisch, Robert Lehmann</Copyright>
+        <PackageLicenseUrl>https://raw.githubusercontent.com/aas-core-works/aas-package3-csharp/main/LICENSE</PackageLicenseUrl>
+        <PackageProjectUrl>https://raw.githubusercontent.com/aas-core-works/aas-package3-csharp</PackageProjectUrl>
+        <PackageTags>aas;asset administration shell;iiot;industry internet of things;industrie 4.0;i4.0</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
These csproj tags are directly used by nuget.org.