### PR TITLE
Fix project URL in csproj

### DIFF
--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
@@ -17,7 +17,7 @@
         <RepositoryType>git</RepositoryType>
         <Copyright>Copyright (c) 2021 Marko Ristin, Nico Braunisch, Robert Lehmann</Copyright>
         <PackageLicenseUrl>https://raw.githubusercontent.com/aas-core-works/aas-package3-csharp/main/LICENSE</PackageLicenseUrl>
-        <PackageProjectUrl>https://raw.githubusercontent.com/aas-core-works/aas-package3-csharp</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/aas-core-works/aas-package3-csharp</PackageProjectUrl>
         <PackageTags>aas;asset administration shell;iiot;industry internet of things;industrie 4.0;i4.0</PackageTags>
     </PropertyGroup>
 


### PR DESCRIPTION
There was a subtle type in the `ProjectUrl` tag in csproj which went
unnoticed.