### PR TITLE
update to net6.0

### DIFF
--- a/src/AasCore.Aas3.Package.Tests/AasCore.Aas3.Package.Tests.csproj
+++ b/src/AasCore.Aas3.Package.Tests/AasCore.Aas3.Package.Tests.csproj
@@ -14,7 +14,7 @@
             NOTE (mristin, 2022-07-23):
             NUnit does not work with netstandard2.0 and 2.1 anymore, so we only test with netstandard2.1.
         --> 
-        <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+        <TargetFramework>net6.0</TargetFramework>
 
         <OutputType>Library</OutputType>
 

--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <Configurations>Debug;Release;DebugSlow</Configurations>
         <Platforms>AnyCPU</Platforms>
         <LangVersion>8</LangVersion>
 
         <PackageId>AasCore.Aas3.Package</PackageId>
-        <Version>1.0.0-pre9</Version>
+        <Version>1.0.0-pre09-dotnet6</Version>
         <Authors>Marko Ristin, Nico Braunisch</Authors>
         <Description>
             A library for reading and writing packaged file format of an Asset Administration Shell (AAS) v3
@@ -22,6 +22,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.IO.Packaging" version="4.*" />
+      <PackageReference Include="System.IO.Packaging" version="6.*" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi Marco, 
we discussed this shortly in our call a few months ago. You said there were some issues with Microsofts Open Packaging Library in .net6. However so far I did not see any issues. 

Is there something I was missing? 

This PR obviously removes the compatbility for older .net "Standard" versions - but it is 2023 and hopefully most folks are updating!

