### PR TITLE
Fix NET version supported in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Aas-package3-csharp is a library for reading and writing packaged file format of
 
 The library is thoroughly tested and meant to be used in production.
 
-NET Standard 2.0, NET Standard 2.1 and NET 5 are supported.
+NET Standard 2.0, NET Standard 2.1 and NET 6 are supported.
 
 ## Documentation
 


### PR DESCRIPTION
We support NET 6 since 1.0.0-pre9, but forgot to update the readme. This patch fixes the reference in the readme.

Fixes #35.