### PR TITLE
Bump System.IO.Packaging from 4.* to 9.*

### DIFF
--- a/src/AasCore.Aas3.Package.Tests/AasCore.Aas3.Package.Tests.csproj
+++ b/src/AasCore.Aas3.Package.Tests/AasCore.Aas3.Package.Tests.csproj
@@ -14,7 +14,7 @@
             NOTE (mristin, 2022-07-23):
             NUnit does not work with netstandard2.0 and 2.1 anymore, so we only test with netstandard2.1.
         --> 
-        <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 
         <OutputType>Library</OutputType>
 
@@ -28,7 +28,7 @@
     <ItemGroup>
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="OpenCover" Version="4.7.1221" />
         <PackageReference Include="coverlet.msbuild" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <Configurations>Debug;Release;DebugSlow</Configurations>
         <Platforms>AnyCPU</Platforms>
@@ -22,6 +22,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.IO.Packaging" version="4.*" />
+      <PackageReference Include="System.IO.Packaging" version="9.*" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
We drop support for net5.0 and net6.0 and add support for net8.0 and net9.0 so that we can use `System.IO.Packaging` 9.* due to vulnerabilities.

We also bump `Microsoft.NET.Test.Sdk` from 17.1.0 to 17.13.0 to fix (other) vulnerabilities.