### PR TITLE
Release 1.0.2

### DIFF
--- a/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
+++ b/src/AasCore.Aas3.Package/AasCore.Aas3.Package.csproj
@@ -8,7 +8,7 @@
         <LangVersion>8</LangVersion>
 
         <PackageId>AasCore.Aas3.Package</PackageId>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
         <Authors>Marko Ristin, Nico Braunisch</Authors>
         <Description>
             A library for reading and writing packaged file format of an Asset Administration Shell (AAS) v3


### PR DESCRIPTION
* Bump System.IO.Packaging from 4.* to 9.* (#46)

  The bump was necessary due to vulnerabilities in System.IO.Packaging 4.*.

  This change involved dropping the support from net5.0 and net6.0, and adding the support for net8.0 and net9.0, which provoked further changes in dev. tooling, but no changes in the library code.