### PR TITLE
Fix path concat in docs generation

### DIFF
--- a/.github/workflows/check-doc.yml
+++ b/.github/workflows/check-doc.yml
@@ -15,12 +15,13 @@ jobs:
       - name: Install .NET 9
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: "9.0.x"
 
       - name: Install dotnet tools
         working-directory: src
         run: dotnet tool restore
 
       - name: Generate the doc
+        shell: pwsh
         working-directory: src
-        run: powershell .\GenerateDoc.ps1
+        run: .\GenerateDoc.ps1

--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -21,8 +21,9 @@ jobs:
         run: dotnet tool restore
 
       - name: Generate the doc
+        shell: pwsh
         working-directory: src
-        run: powershell .\GenerateDoc.ps1
+        run: .\GenerateDoc.ps1
 
       - name: Deploy to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
The script for the docs generation fails due to an issue in the way paths
are concatinated. The issue lies within the fact that the CI server uses
powershell v5, whereas the path concatination with multiple arguments is
only available in v7. Hence, we ensure to use the correct version of
powershell in the CI.
